### PR TITLE
fix(docs): broken link for community contribution lifecycle and processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Reporting bugs is an important contribution. Please make sure to include:
 ### Before you start
 
 Please read project contribution
-[guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+[guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/processes.md)
 for general practices for OpenTelemetry project.
 
 #### Conventional commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Reporting bugs is an important contribution. Please make sure to include:
 ### Before you start
 
 Please read project contribution
-[guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/processes.md)
+[guide](https://github.com/open-telemetry/community/blob/main/guides/contributor)
 for general practices for OpenTelemetry project.
 
 #### Conventional commit


### PR DESCRIPTION
## Which problem is this PR solving?

- The current link is broken https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md

## Short description of the changes

- Fixes the broken link for contribution processes which were moved in https://github.com/open-telemetry/community/pull/2051
